### PR TITLE
Update for new controller

### DIFF
--- a/src/main/scala/org/allenai/example/webapp/SampleService.scala
+++ b/src/main/scala/org/allenai/example/webapp/SampleService.scala
@@ -19,7 +19,7 @@ class SampleService(implicit ec: ExecutionContext) extends Directives with Spray
 
   def query(text: String): Future[StringMessage] = {
     Future {
-      val query = "http://localhost:8080/ask?text=" + URLEncoder.encode(text, "UTF-8")
+      val query = "http://localhost:8080/ask?text=" + URLEncoder.encode(text, "UTF-8") + "&solvers=tableilp"
       StringMessage(Source.fromURL(query).mkString)
     }
   }

--- a/webapp/app/main.jsx
+++ b/webapp/app/main.jsx
@@ -519,7 +519,7 @@ class TableVisualizer extends React.Component {
         if (this.state.loading) {
             loading = <span>Loading...</span>;
         }
-        var suggestedQueries = (<select onChange={self.setSuggestedQuery.bind(this)}> {suggestions} </select>);
+        var suggestedQueries = (<select onChange={self.setSuggestedQuery.bind(this)} size="4"> {suggestions} </select>);
         return (
             <div>
                 <section>
@@ -578,7 +578,7 @@ class TableVisualizer extends React.Component {
                     <Button onClick={this.handleClean.bind(this)}>Clean</Button>
                     <br />
                     <br />
-                    <select onChange={this.handleSelectChange.bind(this)} size="5"> {questions} </select>
+                    <select onChange={this.handleSelectChange.bind(this)} size="4"> {questions} </select>
                 </Panel>
                 {noResponseWarning}
                 {statistics}

--- a/webapp/app/main.jsx
+++ b/webapp/app/main.jsx
@@ -578,7 +578,7 @@ class TableVisualizer extends React.Component {
                     <Button onClick={this.handleClean.bind(this)}>Clean</Button>
                     <br />
                     <br />
-                    <select onChange={this.handleSelectChange.bind(this)}> {questions} </select>
+                    <select onChange={this.handleSelectChange.bind(this)} size="5"> {questions} </select>
                 </Panel>
                 {noResponseWarning}
                 {statistics}


### PR DESCRIPTION
@danyaljj A couple of small changes:
- Oyvind's recent updates to the Controller allow specifying the solvers as part of the `get` request.  Added it here and hardwired `tableilp` as the solver.  This will enable running the visualizer on `aristo-dev.dev.ai2` for people to use!
- @tusharkhot 's convenient fix to see multiple questions in the UI and search more easily.
